### PR TITLE
Adds where() similar to tidyselect

### DIFF
--- a/macros/map.sql
+++ b/macros/map.sql
@@ -1,0 +1,12 @@
+{% macro map(input_list, fn) %}
+
+{% set results_list = [] %}
+{% for l in input_list %}
+    {% if fn(l) %}
+        {{ results_list.append(l) or "" }}
+    {% endif %}
+{% endfor %}
+
+{{ return(results_list) }}
+
+{% endmacro %}

--- a/macros/select_helpers.sql
+++ b/macros/select_helpers.sql
@@ -61,6 +61,15 @@
 {% endmacro %}
 
 
+{% macro where(fn, relation) %}
+
+{%set cols = adapter.get_columns_in_relation(relation) %}
+{%set results = dbtplyr.map(cols, fn) %}
+{{return(results)}}
+
+{% endmacro %}
+
+
 {% macro everything(relation) %}
 
 {%set cols = dbtplyr.get_column_names(relation) %}


### PR DESCRIPTION
Similar to `where()` in [tidyselect](https://dplyr.tidyverse.org/reference/select.html). This enables column filtering like:

```
{% macro col_is_string(col) %}
    {{ return(col.is_string()) }}
{% endmacro %}

{{ dbtplyr.where(col_is_string, source('dev_dan','stg_access_rcrm_timesheets')) }}
```