### PR TITLE
call block with arguments

### DIFF
--- a/analysis/demo.sql
+++ b/analysis/demo.sql
@@ -1,0 +1,14 @@
+{% set cols = dbtplyr.get_column_names( source('chinook','albums') ) %}
+{% set cols_n = dbtplyr.ends_with('Id', cols) %}
+{% set cols_ind = dbtplyr.ends_with('Id', cols) %}
+
+select
+
+  {% call(var) dbtplyr.across(cols_n) %}
+    sum({{var}}) as {{var}}_tot
+  {% endcall %},
+  {% call(var) dbtplyr.across(cols_ind) %}
+    avg({{var}}) as {{var}}_avg
+  {% endcall %}
+
+from {{ source('chinook','albums') }}

--- a/analysis/src_analysis.yml
+++ b/analysis/src_analysis.yml
@@ -1,0 +1,10 @@
+version: 2
+
+# Uses SQLite: https://github.com/codeforkjeff/dbt-sqlite/blob/main/README.md
+sources:
+  - name: chinook
+    schema: main
+    database: main
+    tables:
+      - name: albums
+      - name: artistss

--- a/macros/across.sql
+++ b/macros/across.sql
@@ -1,7 +1,7 @@
-{% macro across(var_list, script_string, final_comma) %}
+{% macro across(var_list, final_comma) %}
 
   {% for v in var_list %}
-  {{ script_string | replace('{{var}}', v) }}
+    {{ caller(v) }}
   {%- if not loop.last %},{% endif %}
   {%- if loop.last and final_comma|default(false) %},{% endif %}
   {% endfor %}


### PR DESCRIPTION
I thought this might be of interest. Rather than pass template SQL as a string argument to `across`, which it then inserts in place of the `{{var}}`, you can use the [call block feature of Jinja](https://jinja.palletsprojects.com/en/3.0.x/templates/#call).

I've included `analysis/demo.sql` which outputs the following SQL:

```sql




select

  

  
    
    sum(AlbumId) as AlbumId_tot
  ,
  
    
    sum(ArtistId) as ArtistId_tot
  
  

,
  

  
    
    avg(AlbumId) as AlbumId_avg
  ,
  
    
    avg(ArtistId) as ArtistId_avg
  
  



from main."albums"
```