### PR TITLE
Accept function-free variables in across by default

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -3,7 +3,7 @@
 # and underscores. A good package name should reflect your organization's
 # name or the intended use of these models
 name: 'dbtplyr'
-version: '0.2.0'
+version: '0.2.1'
 config-version: 2
 require-dbt-version: ">=0.19.0"
 

--- a/integration_tests/models/starts_with.sql
+++ b/integration_tests/models/starts_with.sql
@@ -1,3 +1,3 @@
 {% set cols_n = dbtplyr.starts_with('amt', ref('data')) %}
-select {{ dbtplyr.across(cols_n, "{{var}}") }}
+select {{ dbtplyr.across(cols_n) }}
 from {{ ref('data') }}

--- a/macros/across.sql
+++ b/macros/across.sql
@@ -1,4 +1,4 @@
-{% macro across(var_list, script_string = '{{var}}', final_comma) %}
+{% macro across(var_list, script_string = '{{var}}', final_comma = false) %}
 
   {% for v in var_list %}
   {{ script_string | replace('{{var}}', v) }}

--- a/macros/across.sql
+++ b/macros/across.sql
@@ -1,4 +1,4 @@
-{% macro across(var_list, script_string, final_comma) %}
+{% macro across(var_list, script_string = '{{var}}', final_comma) %}
 
   {% for v in var_list %}
   {{ script_string | replace('{{var}}', v) }}

--- a/macros/macro.yml
+++ b/macros/macro.yml
@@ -34,7 +34,8 @@ macros:
       type: 'String'
       description: >
         'String of script to include for each variable 
-        with variable name abstracted to \{\{var\}\}'
+        with variable name abstracted to \{\{var\}\}.
+'       By default, will return column names with no transformation.'
     - name: final_comma
       type: 'Boolean'
       description: > 

--- a/macros/macro.yml
+++ b/macros/macro.yml
@@ -35,7 +35,7 @@ macros:
       description: >
         'String of script to include for each variable 
         with variable name abstracted to \{\{var\}\}.
-'       By default, will return column names with no transformation.'
+        By default, will return column names with no transformation.'
     - name: final_comma
       type: 'Boolean'
       description: > 


### PR DESCRIPTION
This sets the default argument of `across(script_string = '{{var}}')` such that when no `script_string` argument is provided, `across` can serve as an iterator to list out variables without applying any function to them. 